### PR TITLE
Dev server regenerates site on directory changes (Issue #39)

### DIFF
--- a/wok/dev_server.py
+++ b/wok/dev_server.py
@@ -53,7 +53,7 @@ class dev_server:
         httpd = HTTPServer((self.host, self.port), req_handler)
         socket_info = httpd.socket.getsockname()
 
-        print("Starting dev server on http://%s:%s... (Ctrl-c to stop)"
+        print("Starting dev server on http://%s:%s... (Ctrl-C to stop)"
                 %(socket_info[0], socket_info[1]))
         print "Serving files from", self.serv_dir
 
@@ -64,7 +64,10 @@ class dev_server:
         else:
             print "Directory monitoring is OFF"
 
-        httpd.serve_forever()
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print "\nStopping development server..."
 
 
 class RebuildHandlerWrapper(object):


### PR DESCRIPTION
Rigged the dev server to check for site source directory changes after every request, and regenerate the site if changes are found. This should work as a (temporary) solution for issue #39.

Because the dev server blocks while waiting for each request, it can currently only check for changes _after_ every request. This means that the user must _refresh the page twice_ for changes to be reflected in the browser.

I'm planning to get this working using either polling or event-based directory monitoring, but this ghetto-fab solution seems to work for now :)
