### PR TITLE
Fix markdown2 renderer

### DIFF
--- a/wok/renderers.py
+++ b/wok/renderers.py
@@ -48,7 +48,7 @@ try:
 
         @classmethod
         def render(cls, plain):
-            return markdown(plain, Markdown.plugins)
+            return markdown(plain, cls.plugins)
 
     all.append(Markdown)
 
@@ -60,7 +60,7 @@ except ImportError:
 if markdown is None:
     try:
         import markdown2
-        class Markdown(Renderer):
+        class Markdown2(Renderer):
             """Markdown2 renderer."""
             extensions = ['markdown', 'mkd', 'md']
 
@@ -70,7 +70,7 @@ if markdown is None:
 
             @classmethod
             def render(cls, plain):
-                return markdown2.markdown(plain, extras=extras)
+                return markdown2.markdown(plain, extras=cls.extras)
 
         all.append(Markdown2)
     except:


### PR DESCRIPTION
- Name should be Markdown2 as that's what the other bit's of code refer 
  to.
- extras need's to be accesed as an attribute of cls
- Driveby fix: Make the Markdown class access it plugins via attribut of cls 
  rather than attribute of Markdown so that if some wants to subclass 
  Markdown, they will be able to overwrite plugins.
