### PR TITLE
Use setuptools. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 
-from distutils.core import setup
+from setuptools import setup
 
 from wok import version
 


### PR DESCRIPTION
When I develop on a project, I normally setup a virtualenv, and then run python setup.py develop in the virtualenv.

I would like to use this for, but it is not available in distutils. This change add support by using setuptools, rather than distutils.
