### PR TITLE
Fix a problem with HeadingAnchors to not write out html as xml

### DIFF
--- a/wok/contrib/hooks.py
+++ b/wok/contrib/hooks.py
@@ -57,7 +57,14 @@ class HeadingAnchors(object):
                 heading.set('id', name)
 
         sio_destination = StringIO()
-        tree.write(sio_destination)
+
+	# Use the extension of the template to determine the type of document 
+	if page.template.filename.endswith(".html") or page.filename.endswith(".htm"):
+        	logging.debug('[HeadingAnchors] outputting {0} as HTML'.format(page))
+	        tree.write(sio_destination, method='html')
+	else:
+        	logging.debug('[HeadingAnchors] outputting {0} as XML'.format(page))
+	        tree.write(sio_destination)
         page.rendered = sio_destination.getvalue()
 
 


### PR DESCRIPTION
This code adds a trivial check on the extension of the template used to generate the file. If the template ends in html or htm it will instruct lxml to treat the stream as HTML.
