### PR TITLE
install_requires / requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-Jinja2>=2.6
-Markdown>=2.1.1
-PyYAML>=3.10
-Pygments>=1.4
-docutils>=0.8.1
+-e .

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,13 @@ setup(
         'Operating System :: POSIX',
         'Programming Language :: Python',
     ],
-    requires=['pyyaml', 'jinja2', 'Markdown', 'docutils', 'Pygments'],
+    install_requires=[
+        'Jinja2>=2.6',
+        'Markdown>=2.1.1',
+        'PyYAML>=3.10',
+        'Pygments>=1.4',
+        'docutils>=0.8.1'
+    ],
     packages=['wok'],
     scripts=['scripts/wok'],
 )


### PR DESCRIPTION
Update setup.py to set install_requires and update requirements.txt to
just install a development copy of the library.

Hey, I was really disappointed yesterday when I did `pip install wok` then `wok --help` and got an import error when trying to import `yaml`. I don't think `requires` is a kwarg `setup` even recognizes, so I changed it to `install_requires` and moved all the requirements from `requirements.txt` there and then made `requirements.txt` just install wok from the current working tree.

Let me know what you think.
