### PR TITLE
Slugify with no extension.

### DIFF
--- a/wok/page.py
+++ b/wok/page.py
@@ -171,6 +171,8 @@ class Page(object):
         if not 'slug' in self.meta:
             if self.filename:
                 filename_no_ext = '.'.join(self.filename.split('.')[:-1])
+                if filename_no_ext == '':
+                    filename_no_ext = self.filename
                 self.meta['slug'] = util.slugify(filename_no_ext)
                 logging.info("You didn't specify a slug, generating it from the "
                              "filename.")


### PR DESCRIPTION
Hey,

This fixes little bug where an IndexError is thrown when slugifying a file with no slug, and no extension on the filename.

Cheers,
Joe
