### PR TITLE
Read with universal newlines; fixes https://github.com/mythmon/wok/issues/93

### DIFF
--- a/wok/page.py
+++ b/wok/page.py
@@ -83,7 +83,7 @@ class Page(object):
         page.path = path
         page.filename = os.path.basename(path)
 
-        with open(path) as f:
+        with open(path, 'rU') as f:
             page.original = f.read().decode('utf-8')
             splits = page.original.split('\n---\n')
 


### PR DESCRIPTION
Recognizes Windows \r\n as if it were proper Unix \n
