### PR TITLE
fix pagination on global site attributes

### DIFF
--- a/wok/page.py
+++ b/wok/page.py
@@ -344,7 +344,7 @@ class Page(object):
 
         # Handle pagination if we needed.
         if 'pagination' in self.meta and 'list' in self.meta['pagination']:
-            extra_pages = self.paginate()
+            extra_pages = self.paginate(templ_vars)
         else:
             extra_pages = []
 
@@ -370,7 +370,7 @@ class Page(object):
 
         return extra_pages
 
-    def paginate(self):
+    def paginate(self, templ_vars):
         extra_pages = []
         logging.debug('called pagination for {0}'.format(self.meta['slug']))
         if 'page_items' not in self.meta['pagination']:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/bin/wok", line 4, in <module>
    Engine()
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/wok/engine.py", line 97, in **init**
    self.generate_site()
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/wok/engine.py", line 135, in generate_site
    self.render_site()
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/wok/engine.py", line 354, in render_site
    new_pages = p.render(templ_vars)
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/wok/page.py", line 345, in render
    extra_pages = self.paginate()
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/wok/page.py", line 386, in paginate
    source = templ_vars['site']
NameError: global name 'templ_vars' is not defined
