### PR TITLE
If no slug is given - create it from the page title as described in the documentation. A...

### DIFF
--- a/wok/engine.py
+++ b/wok/engine.py
@@ -29,6 +29,7 @@ class Engine(object):
         'site_title': 'Some random Wok site',
         'url_pattern': '/{category}/{slug}{page}.{ext}',
         'url_include_index': True,
+        'slug_from_filename': False,
         'relative_urls': False,
         'locale': None,
         'markdown_extra_plugins': [],

--- a/wok/page.py
+++ b/wok/page.py
@@ -169,7 +169,7 @@ class Page(object):
 
         # slug
         if not 'slug' in self.meta:
-            if self.filename:
+            if self.filename and self.options['slug_from_filename']:
                 filename_no_ext = '.'.join(self.filename.split('.')[:-1])
                 if filename_no_ext == '':
                     filename_no_ext = self.filename


### PR DESCRIPTION
... config parameter has been added to base the slug on the filename.

It changes default behavior so another solution is to default to create the slug from filename (as it does now) and then update the documentation to reflect this. Let me know.