### PR TITLE
Added a way to override or define new renderers.

### DIFF
--- a/docs/content/docs/renderers.mkd
+++ b/docs/content/docs/renderers.mkd
@@ -135,3 +135,68 @@ Alternatively, you could download a pre-genered pygments CSS file from [this
 repository][pygcss].
 
 [pygcss]: https://github.com/Anomareh/pygments-styles-dump
+
+Overriding renderers
+--------------------
+
+Since version 1.2, wok provides a way to configure the renderers used
+by the site generation pipeline. This can be useful in the following cases.
+
+-   The renderer attached to some extension is not the one that should
+    be called.
+-   Some files need specific treatment that can't be handled by the
+    renderers proposed by default.
+
+The renderers interface is built like the one used to setup
+[hooks](/docs/hooks). Make a new directory in your site root named
+`renderers`. In this directory, create the file `__renderers__.py`.
+For example:
+
+    ::text
+    site-root/
+        |-- config
+        |-- content/
+        |-- hooks/
+        |-- renderers/
+        |   |-- __renderers__.py
+        |   |-- vcard_renderer.py
+        |   `-- html_filter.py
+        |
+        |-- media/
+        |-- output/
+        `-- templates/
+
+From the `__renderers__.py` file, wok will import the variable
+`renderers` which should be a dictionary; the keys are filename
+extensions, and the values are the renderer to use. If a key is
+already defined internally (like `md` or `txt` respectively for
+Markdown or plain text rendering), the renderer defined here will
+override the default one.
+
+A renderer can be any object, class or module as long as it provides a
+`render` function which takes the input document as argument, and
+returns the formatted result. For example:
+
+    ::python
+    ''' __renderers__.py
+
+    Defines wok renderers.
+    '''
+    from bs4 import BeautifulSoup
+
+    class HtmlRenderer(object):
+        @classmethod
+        def render(cls, plain):
+            '''Parse the given HTML document and return only its body.'''
+            soup = BeautifulSoup(plain)
+            return soup.body
+
+    renderers = {
+        'html': HtmlRenderer
+    }
+
+The test site that can be found in [sources][gh] provides the same
+feature with a different syntax.
+
+[gh]: https://github.com/mythmon/wok
+

--- a/test_site/content/tests/html_renderer.html
+++ b/test_site/content/tests/html_renderer.html
@@ -1,0 +1,32 @@
+title: HTML Renderer Test Page
+slug: html-renderer
+category: tests
+tags: [renderers, sample]
+author: [Me <me@nowhere.com>, Myself <myself@nowhere.com>, I <i@nowhere.com>]
+---
+<html>
+<head>
+  <title>This is the HTML Renderer test page</title>
+  <meta charset="utf-8">
+  <meta name="author" content="I">
+  <meta name="description" content="Some broken meta-information that will be dropped while rendering" />
+  <meta name="generator" content="By hand" />
+  <meta name="keywords" content="wok, renderer, python, soup" />
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
+</head>
+<body>
+  <h1>This is a sample HTML test page</h1>
+  <p>
+    This page is rendered by a special renderer which is provided in
+    the <code>renderers</code> directory, with the help of
+    the <b>BeautifulSoup</b> python package.
+  </p>
+  <p>
+    The source document contains a <em>long</em> header
+    with <code>meta</code> and <code>link</code> tags that should be
+    dropped, leaving only a the content of the <code>body</code>; a
+    title and these two paragraphs.
+  </p>
+</body>

--- a/test_site/renderers/__renderers__.py
+++ b/test_site/renderers/__renderers__.py
@@ -1,0 +1,21 @@
+import logging
+
+try:
+    from bs4 import BeautifulSoup
+    def render(plain):
+        soup = BeautifulSoup(plain)
+        return soup.body
+
+except ImportError:
+    import cgi
+    logging.warning('HTML rendering relies on the BeautifulSoup library.')
+    def render(plain):
+        return '<h1>Rendering error</h1>' \
+            + '<p><code>BeautifulSoup</code> could not be loaded.</p>' \
+            + '<p>Original plain document follows:</p>' \
+            + '<p>' + cgi.escape(plain) + '</p>'
+
+
+renderers = {
+    'html': type('',(object,), { 'render': staticmethod(render) })
+}

--- a/wok/tests/test_engine.py
+++ b/wok/tests/test_engine.py
@@ -1,0 +1,91 @@
+import os
+import shutil
+import sys
+import tempfile
+
+try:
+    from twisted.trial.unittest import TestCase
+except ImportError:
+    from unittest import TestCase
+
+from wok import renderers
+from wok.engine import Engine
+
+
+DefaultRenderers = {}
+
+def setUpModule():
+    for renderer in renderers.all:
+        DefaultRenderers.update((ext, renderer) for ext in renderer.extensions)
+
+
+class TestEngine(TestCase):
+
+    def setUp(self):
+        self.tmp_path = tempfile.mkdtemp()
+        os.chdir(self.tmp_path)
+
+    def tearDown(self):
+        os.chdir('..')
+        if self.tmp_path is not None:
+            shutil.rmtree(self.tmp_path)
+            self.tmp_path = None
+        if '__hooks__' in sys.modules:
+            del sys.modules['__hooks__']
+        if '__renderers__' in sys.modules:
+            del sys.modules['__renderers__']
+
+    def test_load_hooks_no_hooks(self):
+        e = Engine.__new__(Engine)
+        e.load_hooks()
+
+        self.assertFalse(hasattr(e, 'hooks'))
+
+    def test_load_hooks_empty_directory(self):
+        os.mkdir('hooks')
+
+        e = Engine.__new__(Engine)
+        e.load_hooks()
+
+        self.assertFalse(hasattr(e, 'hooks'))
+
+    def test_load_hooks(self):
+        os.mkdir('hooks')
+        with open(os.path.join('hooks', '__hooks__.py'), 'a') as f:
+            f.write('hooks = { "name": "action" }\n')
+
+        e = Engine.__new__(Engine)
+        e.load_hooks()
+
+        self.assertIsInstance(e.hooks, dict)
+        self.assertIn('name', e.hooks)
+        self.assertEqual(e.hooks['name'], 'action')
+
+    def test_load_renderers_no_ext_renderers(self):
+        e = Engine.__new__(Engine)
+        e.load_renderers()
+
+        self.assertIsInstance(e.renderers, dict)
+        self.assertDictEqual(e.renderers, DefaultRenderers)
+
+    def test_load_renderers_empty_directory(self):
+        os.mkdir('renderers')
+
+        e = Engine.__new__(Engine)
+        e.load_renderers()
+
+        self.assertIsInstance(e.renderers, dict)
+        self.assertDictEqual(e.renderers, DefaultRenderers)
+
+    def test_load_renderers(self):
+        os.mkdir('renderers')
+        with open(os.path.join('renderers', '__renderers__.py'), 'a') as f:
+            f.write('renderers = { "html": "class" }\n')
+
+        e = Engine.__new__(Engine)
+        e.load_renderers()
+
+        self.assertIsInstance(e.renderers, dict)
+        self.assertDictContainsSubset(DefaultRenderers, e.renderers)
+        self.assertIn('html', e.renderers)
+        self.assertEqual(e.renderers['html'], 'class')


### PR DESCRIPTION
I needed a way to process some pages specifically. (As an exemple, I store the list of books I read as a bibliography, and I want the result HTML page to have some interesting features like block collapses, and distinct classes for comics or essays for example.)

I could have used hooks, but it would have been uselessly complicated since this is the job of the renderer. So I have added a way to add new renderers, in the spirit of what was done for hooks. In the same time, I have slightly optimised the process of searching the renderer to apply on a page. I hope you will be interested in this, or return useful comments if not.