### PR TITLE
url_use_index -> url_include_index in README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -178,7 +178,7 @@ Possible configuration options (and their defaults) are
     -   `{date}`, `{datetime}`, and `{time}` - The date/time from the metadata
         of the page
 
-- `url_use_index` (Yes) - If true, keep `index.*` in urls.
+- `url_include_index` (Yes) - If true, keep `index.*` in urls.
 
 More info:
 [config](http://wok.mythmon.com/docs/config/),

--- a/docs/content/docs/content.mkd
+++ b/docs/content/docs/content.mkd
@@ -48,8 +48,8 @@ pages in the YAML metadata.
     `projects/wok/docs` means the page is in the category `docs` which is a
     subcategory of `wok` which is a subcategory of
      `projects`.
- -  `tags` - A comma-separated list of tags, e.g., `foo, bar, herp, derp`.
-    ([More about tagging][tagging])
+ -  `tags` - A comma-separated list of tags in square brackets, e.g.,
+    `[foo, bar, herp, derp]`. ([More about tagging][tagging])
  -  `published` - To exclude some pages from the site, but not remove them
     entirely.
  -  `url` - To manually specify the path for the generated page. If none is

--- a/docs/content/docs/hooks.mkd
+++ b/docs/content/docs/hooks.mkd
@@ -167,14 +167,14 @@ will pass to the hooked functions (if any.)
 :   This hook will be called for each page before the page is sent to
     the template engine. At this point, the content has been transformed
     from markup input (such as markdown) to html output, if applicable.
-    The transformed version is in `templ_vars['content']`. If you
+    The transformed version is in `templ_vars['page']['content']`. If you
     modify the `templ_vars` parameter, those changes will be visible to
     the template engine. The given functions should take in these two
     variables.
 
 [templates]: /docs/templates/
 
-`page.template.post(config, page)` <a name="page.template.postpage"> </a>
+`page.template.post(config, page)` <a name="page.template.post"> </a>
 :   `config`
     :   Dictionary containing site configuration
 :   `page`


### PR DESCRIPTION
Looks like there's no 'url_use_index' setting anymore.