### PR TITLE
Ensure that title is a string

### DIFF
--- a/wok/page.py
+++ b/wok/page.py
@@ -178,7 +178,7 @@ class Page(object):
                 logging.info("You didn't specify a slug, generating it from the "
                              "filename.")
             else:
-                self.meta['slug'] = slugify(self.meta['title'])
+                self.meta['slug'] = slugify(str(self.meta['title']))
                 logging.info("You didn't specify a slug, and no filename "
                              "exists. Generating the slug from the title.")
 


### PR DESCRIPTION
I *think* that along with #135, this will get the tests all green again. It was still that stupid 404 page.