### PR TITLE
support new config option ignore_files for issue #138

### DIFF
--- a/test_site/config
+++ b/test_site/config
@@ -2,3 +2,4 @@ site_title: Wok Scratch Site
 author: Default
 url_pattern: "/{category}/{slug}{page}/index.{ext}"
 url_include_index: no
+ignore_files: [ '*_ignore', '*~' ]

--- a/test_site/content/tests.mkd_ignore
+++ b/test_site/content/tests.mkd_ignore
@@ -1,0 +1,16 @@
+title: Tests Main
+slug: tests
+type: index
+url: /index{page}.html
+---
+This is a bogus file should be ignored by Wok if the configuration
+directive
+```
+ignore_files = [ '*_ignore' ]
+```
+is set.
+
+
+These are the tests
+
+The pagination test is [here](/pagination/index.html).

--- a/test_site/templates/default.html_ignore
+++ b/test_site/templates/default.html_ignore
@@ -1,0 +1,23 @@
+<!--
+This is a deliberately bogus template file inserted to test the new
+"ignore_files" config directive.  Without specifing
+ignore_files = [ '*_ignore' ]
+in the config file, this file would cause Wok to generate a
+duplicate/ambiguous template error.
+-->
+{% extends "base.html" %}
+{% block body %}
+    <h1>{{ page.title }}</h1>
+    <h2>by: {% for author in page.authors %}
+        {{author}}{% if not loop.last %}, {% endif %}
+    {% endfor %}</h2>
+    <h2>datetime: {{page.datetime}}, date: {{page.date}}, time: {{page.time}}</h2>
+    <h3>Tags:</h3>
+    <ul>
+    {% for tag in page.tags %}
+        <li>{{ tag }}</li>
+    {% endfor %}
+    </ul>
+    Hooked: {{ hooked }}
+    {{ page.content }}
+{% endblock body %}

--- a/wok/engine.py
+++ b/wok/engine.py
@@ -350,8 +350,8 @@ class Engine(object):
         for root, dirs, files in os.walk(self.options['content_dir']):
             # Filter out files if they match any of the ignore patterns
             for ig in self.options['ignore_files']:
-                files = [ f for f in files if not \
-                        fnmatch.fnmatch(os.path.basename(f), ig) ]
+                files = [ f for f in files 
+                        if not fnmatch.fnmatch(os.path.basename(f), ig) ]
             # Grab all the parsable files
             for f in files:
                 # Don't parse hidden files.

--- a/wok/engine.py
+++ b/wok/engine.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import shutil
+import fnmatch
 from datetime import datetime
 from optparse import OptionParser, OptionGroup
 import logging
@@ -33,6 +34,7 @@ class Engine(object):
         'relative_urls': False,
         'locale': None,
         'markdown_extra_plugins': [],
+        'ignore_files': [],
     }
     SITE_ROOT = os.getcwd()
 
@@ -346,6 +348,10 @@ class Engine(object):
 
         # Load files
         for root, dirs, files in os.walk(self.options['content_dir']):
+            # Filter out files if they match any of the ignore patterns
+            for ig in self.options['ignore_files']:
+                files = [ f for f in files if not \
+                        fnmatch.fnmatch(os.path.basename(f), ig) ]
             # Grab all the parsable files
             for f in files:
                 # Don't parse hidden files.

--- a/wok/jinja.py
+++ b/wok/jinja.py
@@ -34,9 +34,9 @@ class GlobFileLoader(FileSystemLoader):
             filenames = glob.glob(globbed_filename)
 
             # Filter out files if they match any of the ignore patterns
-            for i in self.ignores:
-                filenames = [ f for f in filenames if not \
-                        fnmatch.fnmatch(os.path.basename(f), i) ]
+            for ig in self.ignores:
+                filenames = [ f for f in filenames 
+                        if not fnmatch.fnmatch(os.path.basename(f), ig) ]
 
             if len(filenames) > 1:
                 raise AmbiguousTemplate(template)

--- a/wok/page.py
+++ b/wok/page.py
@@ -29,7 +29,8 @@ class Page(object):
     def create_tmpl_env(cls, options):
         cls.tmpl_env = jinja2.Environment(
                 loader=GlobFileLoader(
-                        options.get('template_dir', 'templates')),
+                        searchpath=options.get('template_dir', 'templates'),
+                        ignores=options.get('ignore_files', [])),
                 extensions=options.get('jinja2_extensions', []))
 
     def __init__(self, options, engine):


### PR DESCRIPTION
I created Issue #138, "Feature request - ignore pattern config item".  I thought I'd take a stab at implementing this.  These changes represent "works for me" status.  :)  The idea is a new config parameter is introduced, "ignore_files", which is a list.  By default, this list is empty, which retains original behavior.  But in my case, I put this in my config file:
```
ignore_files = [ '*~' ]
```
This, along with the corresponding code changes, allows Wok to ignore files that match that glob pattern.  Those are backup files created by my editor (vim).  Without this patch, I was basically doing a "find ./ -name "*~" -delete" before invoking Wok, else I would get this error for templates:
```
ERROR:root:Ambiguous template found. There are two files that match "default.*". Aborting.
```
and this for content files:
```
WARNING:root:No parser found for my_content.rst~. Using default renderer.
```
This is my first time using GitHub for anything other than a simple clone, please go easy on me!