### PR TITLE
Fix loading package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
         'pytest==2.5.2',
     ],
     packages=['wok'],
+    package_data={'wok':['contrib/*']},
     scripts=['scripts/wok'],
 )


### PR DESCRIPTION
The proposed PR is going to fix `ImportError: No module named contrib.hooks` while importing `wok.contrib.hooks` module mainly because files from `contrib` directory are not copied during installation of a package. Resolves #90.