### PR TITLE
Fix: rst - wrong handling of initial lonely heading

### DIFF
--- a/docs/content/docs/config.mkd
+++ b/docs/content/docs/config.mkd
@@ -31,6 +31,10 @@ are:
 - `relative_urls` (false) - If this option is turned on, then any urls
   generated will not include a leading '/'. If this is false, all urls
   generated will include a leading '/'.
+- `rst_doctitle` (false) - Disable rst/docutils' promotion of a lone top-level
+  section title to document title (was enabled up to wok 1.1.1 - by mistake).
+  Might be optionally enabled here (or on per page basis) again - for backwards
+  compatibility.
 
 [content]: /docs/content/
 [URLs]: /docs/urls/

--- a/docs/content/docs/content.mkd
+++ b/docs/content/docs/content.mkd
@@ -57,6 +57,9 @@ pages in the YAML metadata.
     configuration file will be used. ([More about managing URLs][URLs])
 -   `pagination` - An object who's presence will trigger paginating this page.
     See [pagination][] for more details.
+-   `rst_doctitle` - Re-enable rst/docutils' promotion of a lone top-level
+    section title to document title.
+    (Only for backwards compatibility - was enabled up to wok 1.1.1 - a bug?)
 
 [8601]: http://en.wikipedia.org/wiki/ISO_8601
 [URLs]: /docs/urls/

--- a/test_site/renderers/__renderers__.py
+++ b/test_site/renderers/__renderers__.py
@@ -2,14 +2,14 @@ import logging
 
 try:
     from bs4 import BeautifulSoup
-    def render(plain):
+    def render(plain, page_meta):
         soup = BeautifulSoup(plain)
         return soup.body
 
 except ImportError:
     import cgi
     logging.warning('HTML rendering relies on the BeautifulSoup library.')
-    def render(plain):
+    def render(plain, page_meta):
         return '<h1>Rendering error</h1>' \
             + '<p><code>BeautifulSoup</code> could not be loaded.</p>' \
             + '<p>Original plain document follows:</p>' \

--- a/wok/engine.py
+++ b/wok/engine.py
@@ -35,6 +35,7 @@ class Engine(object):
         'locale': None,
         'markdown_extra_plugins': [],
         'ignore_files': [],
+        'rst_doctitle': False,
     }
     SITE_ROOT = os.getcwd()
 
@@ -246,6 +247,12 @@ class Engine(object):
             renderers.Markdown.plugins.extend(markdown_extra_plugins)
         if hasattr(renderers, 'Markdown2'):
             renderers.Markdown2.extras.extend(markdown_extra_plugins)
+
+        # reStructuredText options
+        if hasattr(renderers, 'ReStructuredText'):
+            renderers.ReStructuredText.options.update( \
+                {'doctitle' : self.options.get('rst_doctitle', False), \
+                })
 
     def sanity_check(self):
         """Basic sanity checks."""

--- a/wok/page.py
+++ b/wok/page.py
@@ -117,8 +117,8 @@ class Page(object):
         page.build_meta()
 
         page.engine.run_hook('page.render.pre', page)
-        page.meta['content'] = page.renderer.render(page.original)
-        page.meta['preview'] = page.renderer.render(page.original_preview)
+        page.meta['content'] = page.renderer.render(page.original, page.meta)  # the page.meta might contain renderer options...
+        page.meta['preview'] = page.renderer.render(page.original_preview, page.meta)
         page.engine.run_hook('page.render.post', page)
 
         return page


### PR DESCRIPTION
Fixes issue #124


Problem:

A lone initial heading isn't handled correctly.
It's treated as document title and as result is missing as topic heading.

Example:

    heading1
    ========

    some text

    heading2
    --------

    more text

gives (shortened):

    <p>some text</p>
    <h1>heading2</h1>
    <p>more text</p>

See: http://docutils.sourceforge.net/docs/api/publisher.html#publish-parts-details
     http://docutils.sourceforge.net/FAQ.html#unexpected-results-from-tools-rst2html-py-h1-h1-instead-of-h1-h2-why

Solution:

Disable the promotion of a lone top-level section title to document title
(and subsequent section title to document subtitle promotion)

See: http://docutils.sourceforge.net/docs/api/publisher.html#id3
     http://docutils.sourceforge.net/docs/user/config.html#doctitle-xform