### PR TITLE
Issue 144 rst source path take2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'Markdown==2.6.5',
         'PyYAML==3.10',
         'Pygments==2.1',
-        'docutils==0.8.1',
+        'docutils>=0.8.1',
         'awesome-slugify==1.4',
         'pytest==2.5.2',
     ],

--- a/wok/page.py
+++ b/wok/page.py
@@ -146,6 +146,12 @@ class Page(object):
         if not self.meta:
             self.meta = {}
 
+        # source_path
+        if not 'source_path' in self.meta:
+            self.meta['source_path'] = None
+            if self.filename:
+                self.meta['source_path'] = self.filename
+
         # title
         if not 'title' in self.meta:
             if self.filename:

--- a/wok/renderers.py
+++ b/wok/renderers.py
@@ -107,7 +107,7 @@ try:
             #      http://docutils.sourceforge.net/docs/user/config.html#doctitle-xform
             #
             overrides = { 'doctitle_xform': page_meta.get('rst_doctitle', cls.options['doctitle']), }
-            return docutils.core.publish_parts(plain, writer=w, settings_overrides=overrides)['body']
+            return docutils.core.publish_parts(plain, writer=w, settings_overrides=overrides, source_path=page_meta['source_path'])['body']
 
     all.append(ReStructuredText)
 except ImportError:


### PR DESCRIPTION
Another PR broke the previous attempt at fixing issue #144.  Looks like now we are now passing page.meta to the render() function.  wok/page.py line 120 has comment, "the page.meta might contain renderer options".  So I added a new metadata field, "source_file".  This value is the input source file name.

For the reStructuredText render, page_meta['source_path'] will be passed to docutils.core.publish_parts().

This allows the source filename to be printed if the renderer encounters an error.